### PR TITLE
Parser-error-rework

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -19,12 +19,11 @@ For Loops
 
 ## Future:
 Rethink if some of the statement enum variants should have a struct instead of directly having members, to make it easier to limit what gets put into what
-Rework parser to throw errors for unexpected tokens
 
 run this with cargo run to run the application, and at the empty line, type something simple like "3 + 5 * 6;", should get 33 printed below that.
 Or type "let x = 3 * 5; x + 3;", should see "> 18" as a response.
 
-See integration tests in interpreter.rs for more examples of simple code that can be run
+See integration tests in integration_tests.rs for more examples of simple code that can be run
 
 ## Tests
 run with cargo test

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -33,7 +33,7 @@ impl Environment {
         self.variables.insert(identifier, (inherited, value.clone()));
     }
 
-    pub fn has_variable(&mut self, identifier: String) -> bool {
+    pub fn has_variable(&self, identifier: String) -> bool {
         self.variables.contains_key(&identifier)
     }
 

--- a/src/integration_tests.rs
+++ b/src/integration_tests.rs
@@ -2,7 +2,7 @@
 mod integration_tests {
     use crate::interpreter::errors::{InterpreterError, InterpreterErrorKind};
     use crate::lexer::tokenize;
-    use crate::parser::Parser;
+    use crate::parser::{Parser, separate_out_statements_and_parser_errors};
     use crate::interpreter::interpreter::{eval_expression, eval_statement, eval_statements};
     use crate::ast::{Expression, ExpressionResult, Statement};
     use crate::environment::Environment;
@@ -31,7 +31,7 @@ mod integration_tests {
         let statements = parser.parse();
         let mut env = Environment::new();
         let expression = match &statements[0] {
-            Statement::ExpressionStatement(expression) => expression,
+            Ok(Statement::ExpressionStatement(expression)) => expression,
             _ => &Expression::NumberLiteral(-255.0),
         };
         let result = eval_expression(expression.clone(), &mut env).unwrap();
@@ -46,7 +46,7 @@ mod integration_tests {
         let statements = parser.parse();
         let mut env = Environment::new();
         let expression = match &statements[0] {
-            Statement::ExpressionStatement(expression) => expression,
+            Ok(Statement::ExpressionStatement(expression)) => expression,
             _ => &Expression::NumberLiteral(-255.0),
         };
         let result = eval_expression(expression.clone(), &mut env).unwrap();
@@ -61,7 +61,7 @@ mod integration_tests {
         let statements = parser.parse();
         let mut env = Environment::new();
         let expression = match &statements[0] {
-            Statement::ExpressionStatement(expression) => expression,
+            Ok(Statement::ExpressionStatement(expression)) => expression,
             _ => &Expression::NumberLiteral(-255.0),
         };
         let result = eval_expression(expression.clone(), &mut env).unwrap();
@@ -76,7 +76,7 @@ mod integration_tests {
         let statements = parser.parse();
         let mut env = Environment::new();
         let expression = match &statements[0] {
-            Statement::ExpressionStatement(expression) => expression,
+            Ok(Statement::ExpressionStatement(expression)) => expression,
             _ => &Expression::NumberLiteral(-255.0),
         };
         let result = eval_expression(expression.clone(), &mut env).unwrap();
@@ -91,7 +91,7 @@ mod integration_tests {
         let statements = parser.parse();
         let mut env = Environment::new();
         let expression = match &statements[0] {
-            Statement::ExpressionStatement(expression) => expression,
+            Ok(Statement::ExpressionStatement(expression)) => expression,
             _ => &Expression::NumberLiteral(-255.0),
         };
         let result = eval_expression(expression.clone(), &mut env).unwrap();
@@ -106,7 +106,7 @@ mod integration_tests {
         let statements = parser.parse();
         let mut env = Environment::new();
         let expression = match &statements[0] {
-            Statement::ExpressionStatement(expression) => expression,
+            Ok(Statement::ExpressionStatement(expression)) => expression,
             _ => &Expression::NumberLiteral(-255.0),
         };
         let result = eval_expression(expression.clone(), &mut env).unwrap();
@@ -121,7 +121,7 @@ mod integration_tests {
         let statements = parser.parse();
         let mut env = Environment::new();
         let expression = match &statements[0] {
-            Statement::ExpressionStatement(expression) => expression,
+            Ok(Statement::ExpressionStatement(expression)) => expression,
             _ => &Expression::NumberLiteral(-255.0),
         };
         let result = eval_expression(expression.clone(), &mut env).unwrap();
@@ -136,7 +136,7 @@ mod integration_tests {
         let statements = parser.parse();
         let mut env = Environment::new();
         let expression = match &statements[0] {
-            Statement::ExpressionStatement(expression) => expression,
+            Ok(Statement::ExpressionStatement(expression)) => expression,
             _ => &Expression::NumberLiteral(-255.0),
         };
         let result = eval_expression(expression.clone(), &mut env).unwrap();
@@ -151,7 +151,7 @@ mod integration_tests {
         let statements = parser.parse();
         let mut env = Environment::new();
         let expression = match &statements[0] {
-            Statement::ExpressionStatement(expression) => expression,
+            Ok(Statement::ExpressionStatement(expression)) => expression,
             _ => &Expression::NumberLiteral(-255.0),
         };
         let result = eval_expression(expression.clone(), &mut env).unwrap();
@@ -166,7 +166,7 @@ mod integration_tests {
         let statements = parser.parse();
         let mut env = Environment::new();
         let expression = match &statements[0] {
-            Statement::ExpressionStatement(expression) => expression,
+            Ok(Statement::ExpressionStatement(expression)) => expression,
             _ => &Expression::NumberLiteral(-255.0),
         };
         let result = eval_expression(expression.clone(), &mut env).unwrap();
@@ -181,7 +181,7 @@ mod integration_tests {
         let statements = parser.parse();
         let mut env = Environment::new();
         let expression = match &statements[0] {
-            Statement::ExpressionStatement(expression) => expression,
+            Ok(Statement::ExpressionStatement(expression)) => expression,
             _ => &Expression::NumberLiteral(-255.0),
         };
         let result = eval_expression(expression.clone(), &mut env).unwrap();
@@ -196,7 +196,7 @@ mod integration_tests {
         let statements = parser.parse();
         let mut env = Environment::new();
         let expression = match &statements[0] {
-            Statement::ExpressionStatement(expression) => expression,
+            Ok(Statement::ExpressionStatement(expression)) => expression,
             _ => &Expression::NumberLiteral(-255.0),
         };
         let result = eval_expression(expression.clone(), &mut env).unwrap();
@@ -211,7 +211,7 @@ mod integration_tests {
         let statements = parser.parse();
         let mut env = Environment::new();
         let expression = match &statements[0] {
-            Statement::ExpressionStatement(expression) => expression,
+            Ok(Statement::ExpressionStatement(expression)) => expression,
             _ => &Expression::NumberLiteral(-255.0),
         };
         let result = eval_expression(expression.clone(), &mut env).unwrap();
@@ -226,7 +226,7 @@ mod integration_tests {
         let statements = parser.parse();
         let mut env = Environment::new();
         let expression = match &statements[0] {
-            Statement::ExpressionStatement(expression) => expression,
+            Ok(Statement::ExpressionStatement(expression)) => expression,
             _ => &Expression::NumberLiteral(-255.0),
         };
         let result = eval_expression(expression.clone(), &mut env).unwrap();
@@ -241,7 +241,7 @@ mod integration_tests {
         let statements = parser.parse();
         let mut env = Environment::new();
         let expression = match &statements[0] {
-            Statement::ExpressionStatement(expression) => expression,
+            Ok(Statement::ExpressionStatement(expression)) => expression,
             _ => &Expression::NumberLiteral(-255.0),
         };
         let result = eval_expression(expression.clone(), &mut env).unwrap();
@@ -256,7 +256,7 @@ mod integration_tests {
         let statements = parser.parse();
         let mut env = Environment::new();
         let expression = match &statements[0] {
-            Statement::ExpressionStatement(expression) => expression,
+            Ok(Statement::ExpressionStatement(expression)) => expression,
             _ => &Expression::NumberLiteral(-255.0),
         };
         let result = eval_expression(expression.clone(), &mut env).unwrap();
@@ -268,16 +268,21 @@ mod integration_tests {
         let input = "let x = 3;  x > 2 && true";
         let tokens = tokenize(input);
         let mut parser = Parser::new(tokens);
-        let statements = parser.parse();
+        let results = parser.parse();
         let mut env = Environment::new();
-        let expression = match &statements[1] {
-            Statement::ExpressionStatement(expression) => expression.clone(),
+        let expression = match &results[1] {
+            Ok(Statement::ExpressionStatement(expression)) => expression.clone(),
             _ => Expression::NumberLiteral(-255.0),
         };
+        let (statements, errors) = separate_out_statements_and_parser_errors(results);
         eval_statements(statements, &mut env);
         assert_eq!(
             env.get_variable("x").unwrap_or(ExpressionResult::Number(-255.0)),
             ExpressionResult::Number(3.0)
+        );
+        assert_eq!(
+            0,
+            errors.len()
         );
         let result = eval_expression(expression.clone(), &mut env).unwrap();
         assert_eq!(result, ExpressionResult::Boolean(true));
@@ -288,12 +293,14 @@ mod integration_tests {
         let input = "let x = 5; !(x > 3)";
         let tokens = tokenize(input);
         let mut parser = Parser::new(tokens);
-        let statements = parser.parse();
+        let results = parser.parse();
         let mut env = Environment::new();
-        let expression = match &statements[1] {
-            Statement::ExpressionStatement(expression) => expression.clone(),
+        let expression = match &results[1] {
+            Ok(Statement::ExpressionStatement(expression)) => expression.clone(),
             _ => Expression::NumberLiteral(-255.0),
         };
+                let (statements, errors) = separate_out_statements_and_parser_errors(results);
+
         eval_statements(statements, &mut env);
         let result = eval_expression(expression.clone(), &mut env).unwrap();
         assert_eq!(result, ExpressionResult::Boolean(false));
@@ -304,12 +311,14 @@ mod integration_tests {
         let input = "let x = 1; !(x > 3)";
         let tokens = tokenize(input);
         let mut parser = Parser::new(tokens);
-        let statements = parser.parse();
+        let results = parser.parse();
         let mut env = Environment::new();
-        let expression = match &statements[1] {
-            Statement::ExpressionStatement(expression) => expression.clone(),
+        let expression = match &results[1] {
+            Ok(Statement::ExpressionStatement(expression)) => expression.clone(),
             _ => Expression::NumberLiteral(-255.0),
         };
+                let (statements, errors) = separate_out_statements_and_parser_errors(results);
+
         eval_statements(statements, &mut env);
         let result = eval_expression(expression.clone(), &mut env).unwrap();
         assert_eq!(result, ExpressionResult::Boolean(true));
@@ -320,12 +329,14 @@ mod integration_tests {
         let input = "let x = 1; !!(x > 3)";
         let tokens = tokenize(input);
         let mut parser = Parser::new(tokens);
-        let statements = parser.parse();
+        let results = parser.parse();
         let mut env = Environment::new();
-        let expression = match &statements[1] {
-            Statement::ExpressionStatement(expression) => expression.clone(),
+        let expression = match &results[1] {
+            Ok(Statement::ExpressionStatement(expression)) => expression.clone(),
             _ => Expression::NumberLiteral(-255.0),
         };
+                let (statements, errors) = separate_out_statements_and_parser_errors(results);
+
         eval_statements(statements, &mut env);
         let result = eval_expression(expression.clone(), &mut env).unwrap();
         assert_eq!(result, ExpressionResult::Boolean(false));
@@ -336,23 +347,24 @@ mod integration_tests {
         let input = "let x = 3; --x; x == 3;";
         let tokens = tokenize(input);
         let mut parser = Parser::new(tokens);
-        let statements = parser.parse();
+        let results = parser.parse();
         let mut env = Environment::new();
-        let expression = match &statements[1] {
-            Statement::ExpressionStatement(expression) => expression.clone(),
+        let expression = match &results[1] {
+            Ok(Statement::ExpressionStatement(expression)) => expression.clone(),
             _ => Expression::NumberLiteral(-255.0),
         };
+        let third_expression = match &results[2] {
+            Ok(Statement::ExpressionStatement(expression)) => expression.clone(),
+            _ => Expression::NumberLiteral(-255.0),
+        };
+        let (statements, errors) = separate_out_statements_and_parser_errors(results);
+
         eval_statement_at_index(&statements, &mut env, 0);
         assert_eq!(env.get_variable("x").unwrap(), ExpressionResult::Number(3.0));
         let result = eval_expression(expression, &mut env).unwrap();
         assert_eq!(result, ExpressionResult::Number(2.0));
         assert_eq!(env.get_variable("x").unwrap(), ExpressionResult::Number(2.0));
-
-        let expression = match &statements[2] {
-            Statement::ExpressionStatement(expression) => expression.clone(),
-            _ => Expression::NumberLiteral(-255.0),
-        };
-        let result = eval_expression(expression, &mut env).unwrap();
+        let result = eval_expression(third_expression, &mut env).unwrap();
         assert_eq!(result, ExpressionResult::Boolean(false));
     }
 
@@ -361,8 +373,9 @@ mod integration_tests {
         let input = "let x = 3; x = 4;";
         let tokens = tokenize(input);
         let mut parser = Parser::new(tokens);
-        let statements = parser.parse();
+        let results = parser.parse();
         let mut env = Environment::new();
+        let (statements, errors) = separate_out_statements_and_parser_errors(results);
 
         eval_statements(statements, &mut env);
 
@@ -375,10 +388,10 @@ mod integration_tests {
         let input = "x = 6;";
         let tokens = tokenize(input);
         let mut parser = Parser::new(tokens);
-        let statements = parser.parse();
+        let results = parser.parse();
         let mut env = Environment::new();
-        let expression = match &statements[0] {
-            Statement::ExpressionStatement(expression) => expression.clone(),
+        let expression = match &results[0] {
+            Ok(Statement::ExpressionStatement(expression)) => expression.clone(),
             _ => Expression::NumberLiteral(-255.0),
         };
         let result = eval_expression(expression, &mut env);
@@ -390,12 +403,14 @@ mod integration_tests {
         let input = "let x = true;  let y = false;  x || y;";
         let tokens = tokenize(input);
         let mut parser = Parser::new(tokens);
-        let statements = parser.parse();
+        let results = parser.parse();
         let mut env = Environment::new();
-        let expression = match &statements[2] {
-            Statement::ExpressionStatement(expression) => expression.clone(),
+        let expression = match &results[2] {
+            Ok(Statement::ExpressionStatement(expression)) => expression.clone(),
             _ => Expression::NumberLiteral(-255.0),
         };
+                let (statements, errors) = separate_out_statements_and_parser_errors(results);
+
         eval_statements(statements, &mut env);
         let result = eval_expression(expression, &mut env);
         assert_eq!(result.unwrap(), ExpressionResult::Boolean(true));
@@ -406,12 +421,14 @@ mod integration_tests {
         let input = "let x = \"apple\";  let y = \"sauce\";  x + y;";
         let tokens = tokenize(input);
         let mut parser = Parser::new(tokens);
-        let statements = parser.parse();
+        let results = parser.parse();
         let mut env = Environment::new();
-        let expression = match &statements[2] {
-            Statement::ExpressionStatement(expression) => expression.clone(),
+        let expression = match &results[2] {
+            Ok(Statement::ExpressionStatement(expression)) => expression.clone(),
             _ => Expression::NumberLiteral(-255.0),
         };
+                        let (statements, errors) = separate_out_statements_and_parser_errors(results);
+
         eval_statements(statements, &mut env);
         let stored_value = env.get_variable("x").unwrap();
         assert_eq!(stored_value, ExpressionResult::String("apple".to_string()));
@@ -430,16 +447,17 @@ mod integration_tests {
         let input = "let x = \"apple\";  let y = 5; let z = false;  x + y; x + z;";
         let tokens = tokenize(input);
         let mut parser = Parser::new(tokens);
-        let statements = parser.parse();
+        let results = parser.parse();
         let mut env = Environment::new();
-        let expression = match &statements[3] {
-            Statement::ExpressionStatement(expression) => expression.clone(),
+        let expression = match &results[3] {
+            Ok(Statement::ExpressionStatement(expression)) => expression.clone(),
             _ => Expression::NumberLiteral(-255.0),
         };
-        let second_expression = match &statements[4] {
-            Statement::ExpressionStatement(expression) => expression.clone(),
+        let second_expression = match &results[4] {
+            Ok(Statement::ExpressionStatement(expression)) => expression.clone(),
             _ => Expression::NumberLiteral(-255.0),
         };
+                        let (statements, errors) = separate_out_statements_and_parser_errors(results);
 
         eval_statements(statements, &mut env);
         let stored_value = env.get_variable("x").unwrap();
@@ -467,25 +485,26 @@ mod integration_tests {
         let second_input = "+x; +y; -x; -y;";
         let tokens = tokenize(&(input.to_owned() + second_input));
         let mut parser = Parser::new(tokens);
-        let statements = parser.parse();
+        let results = parser.parse();
         
         let mut env = Environment::new();
-        let expression = match &statements[2] {
-            Statement::ExpressionStatement(expression) => expression.clone(),
+        let expression = match &results[2] {
+            Ok(Statement::ExpressionStatement(expression)) => expression.clone(),
             _ => Expression::NumberLiteral(-255.0),
         };
-        let second_expression = match &statements[3] {
-            Statement::ExpressionStatement(expression) => expression.clone(),
+        let second_expression = match &results[3] {
+            Ok(Statement::ExpressionStatement(expression)) => expression.clone(),
             _ => Expression::NumberLiteral(-255.0),
         };
-        let third_expression = match &statements[4] {
-            Statement::ExpressionStatement(expression) => expression.clone(),
+        let third_expression = match &results[4] {
+            Ok(Statement::ExpressionStatement(expression)) => expression.clone(),
             _ => Expression::NumberLiteral(-255.0),
         };
-        let fourth_expression = match &statements[5] {
-            Statement::ExpressionStatement(expression) => expression.clone(),
+        let fourth_expression = match &results[5] {
+            Ok(Statement::ExpressionStatement(expression)) => expression.clone(),
             _ => Expression::NumberLiteral(-255.0),
         };
+        let (statements, errors) = separate_out_statements_and_parser_errors(results);
 
         eval_statements(statements, &mut env);
         let stored_value = env.get_variable("x").unwrap();
@@ -517,10 +536,12 @@ mod integration_tests {
         let statements = parser.parse();
         let mut env = Environment::new();
         let second_expression = match &statements[1] {
-            Statement::ExpressionStatement(expression) => expression.clone(),
+            Ok(Statement::ExpressionStatement(expression)) => expression.clone(),
             _ => Expression::NumberLiteral(-255.0),
         };
-        eval_statement(statements[0].clone(), &mut env);
+        if let Ok(statement) = &statements[0] {
+            eval_statement(statement.clone(), &mut env);
+        }
         assert_eq!(
             env.get_variable("x").unwrap(), ExpressionResult::Boolean(true)
         );
@@ -541,7 +562,7 @@ mod integration_tests {
         let statements = parser.parse();
         let mut env = Environment::new();
         let expression = match &statements[0] {
-            Statement::ExpressionStatement(expression) => expression.clone(),
+            Ok(Statement::ExpressionStatement(expression)) => expression.clone(),
             _ => Expression::NumberLiteral(-255.0),
         };
         let result = eval_expression(expression, &mut env);
@@ -558,12 +579,14 @@ mod integration_tests {
         ";
         let tokens = tokenize(input);
         let mut parser = Parser::new(tokens);
-        let statements = parser.parse();
+        let results = parser.parse();
         let mut env = Environment::new();
-        let expression = match &statements[1] {
-            Statement::ExpressionStatement(expression) => expression.clone(),
+        let expression = match &results[1] {
+            Ok(Statement::ExpressionStatement(expression)) => expression.clone(),
             _ => Expression::NumberLiteral(-255.0),
         };
+        let (statements, errors) = separate_out_statements_and_parser_errors(results);
+
         eval_statements(statements.clone(), &mut env);
         let result = eval_expression(expression, &mut env);
 
@@ -586,12 +609,14 @@ mod integration_tests {
         ";
         let tokens = tokenize(input);
         let mut parser = Parser::new(tokens);
-        let statements = parser.parse();
+        let results = parser.parse();
         let mut env = Environment::new();
-        let expression = match &statements[1] {
-            Statement::ExpressionStatement(expression) => expression.clone(),
+        let expression = match &results[1] {
+            Ok(Statement::ExpressionStatement(expression)) => expression.clone(),
             _ => Expression::NumberLiteral(-255.0),
         };
+        let (statements, errors) = separate_out_statements_and_parser_errors(results);
+
         eval_statements(statements.clone(), &mut env);
         let result = eval_expression(expression, &mut env);
 
@@ -616,14 +641,14 @@ mod integration_tests {
         ";
         let tokens = tokenize(input);
         let mut parser = Parser::new(tokens);
-        let statements = parser.parse();
+        let results = parser.parse();
         let mut env = Environment::new();
 
-        let second_function_call = match &statements[2] {
-            Statement::ExpressionStatement(expression) => expression.clone(),
+        let second_function_call = match &results[2] {
+            Ok(Statement::ExpressionStatement(expression)) => expression.clone(),
             _ => Expression::NumberLiteral(-255.0),
         };
-
+        let (statements, errors) = separate_out_statements_and_parser_errors(results);
         eval_statements(statements.clone(), &mut env);
         let x = env.get_variable("x".into());
 
@@ -651,12 +676,14 @@ mod integration_tests {
         ";
         let tokens = tokenize(input);
         let mut parser = Parser::new(tokens);
-        let statements = parser.parse();
+        let results = parser.parse();
         let mut env = Environment::new();
-        let expression = match &statements[1] {
-            Statement::ExpressionStatement(expression) => expression.clone(),
+        let expression = match &results[1] {
+            Ok(Statement::ExpressionStatement(expression)) => expression.clone(),
             _ => Expression::NumberLiteral(-255.0),
         };
+        let (statements, errors) = separate_out_statements_and_parser_errors(results);
+
         eval_statements(statements.clone(), &mut env);
         let result = eval_expression(expression, &mut env);
 
@@ -681,10 +708,12 @@ mod integration_tests {
         ";
         let tokens = tokenize(input);
         let mut parser = Parser::new(tokens);
-        let statements = parser.parse();
+        let results = parser.parse();
 
-        let mut env = Environment::new();
+        let mut env: Environment = Environment::new();
+        let (statements, errors) = separate_out_statements_and_parser_errors(results);
         assert_eq!(statements.len(), 2);
+
         eval_statements(statements.clone(), &mut env);
         assert_eq!(
             env.get_variable("x".into()),
@@ -702,10 +731,12 @@ mod integration_tests {
         ";
         let tokens = tokenize(input);
         let mut parser = Parser::new(tokens);
-        let statements = parser.parse();
+        let results = parser.parse();
 
         let mut env = Environment::new();
-        assert_eq!(statements.len(), 2);
+        assert_eq!(results.len(), 2);
+        let (statements, errors) = separate_out_statements_and_parser_errors(results);
+
         eval_statements(statements.clone(), &mut env);
         assert_eq!(
             env.get_variable("x".into()),
@@ -725,8 +756,9 @@ mod integration_tests {
 
         let tokens = tokenize(input);
         let mut parser = Parser::new(tokens);
-        let statements = parser.parse();
+        let results = parser.parse();
         let mut env = Environment::new();
+        let (statements, errors) = separate_out_statements_and_parser_errors(results);
         eval_statements(statements.clone(), &mut env);
         assert_eq!(
             env.get_variable("x".into()),
@@ -754,8 +786,9 @@ mod integration_tests {
 
         let tokens = tokenize(input);
         let mut parser = Parser::new(tokens);
-        let statements = parser.parse();
+        let results = parser.parse();
         let mut env = Environment::new();
+        let (statements, errors) = separate_out_statements_and_parser_errors(results);
         eval_statements(statements.clone(), &mut env);
         assert_eq!(
             env.get_variable("x".into()),
@@ -784,8 +817,9 @@ mod integration_tests {
 
         let tokens = tokenize(input);
         let mut parser = Parser::new(tokens);
-        let statements = parser.parse();
+        let results = parser.parse();
         let mut env = Environment::new();
+        let (statements, errors) = separate_out_statements_and_parser_errors(results);
         eval_statements(statements.clone(), &mut env);
         assert_eq!(
             env.get_variable("x".into()),
@@ -806,8 +840,9 @@ mod integration_tests {
 
         let tokens = tokenize(input);
         let mut parser = Parser::new(tokens);
-        let statements = parser.parse();
+        let results = parser.parse();
         let mut env = Environment::new();
+        let (statements, errors) = separate_out_statements_and_parser_errors(results);
         eval_statements(statements.clone(), &mut env);
         assert_eq!(
             env.get_variable("x".into()),
@@ -823,8 +858,9 @@ mod integration_tests {
 
         let tokens = tokenize(input);
         let mut parser = Parser::new(tokens);
-        let statements = parser.parse();
+        let results = parser.parse();
         let mut env = Environment::new();
+        let (statements, errors) = separate_out_statements_and_parser_errors(results);
         eval_statements(statements.clone(), &mut env);
         assert_eq!(
             env.get_variable("x".into()),
@@ -841,8 +877,9 @@ mod integration_tests {
 
         let tokens = tokenize(input);
         let mut parser = Parser::new(tokens);
-        let statements = parser.parse();
+        let results = parser.parse();
         let mut env = Environment::new();
+        let (statements, errors) = separate_out_statements_and_parser_errors(results);
         eval_statements(statements.clone(), &mut env);
         assert_eq!(
             env.get_variable("x".into()),
@@ -859,8 +896,9 @@ mod integration_tests {
 
         let tokens = tokenize(input);
         let mut parser = Parser::new(tokens);
-        let statements = parser.parse();
+        let results = parser.parse();
         let mut env = Environment::new();
+        let (statements, errors) = separate_out_statements_and_parser_errors(results);
         eval_statements(statements.clone(), &mut env);
         assert_eq!(
             env.get_variable("x".into()),
@@ -881,9 +919,9 @@ mod integration_tests {
 
         let tokens = tokenize(input);
         let mut parser = Parser::new(tokens);
-        let statements = parser.parse();
-
+        let results = parser.parse();
         let mut env = Environment::new();
+        let (statements, errors) = separate_out_statements_and_parser_errors(results);
         eval_statements(statements.clone(), &mut env);
         assert_eq!(
             env.get_variable("x".into()),
@@ -904,9 +942,9 @@ mod integration_tests {
 
         let tokens = tokenize(input);
         let mut parser = Parser::new(tokens);
-        let statements = parser.parse();
-
+        let results = parser.parse();
         let mut env = Environment::new();
+        let (statements, errors) = separate_out_statements_and_parser_errors(results);
         eval_statements(statements.clone(), &mut env);
         assert_eq!(
             env.get_variable("x".into()),
@@ -929,9 +967,9 @@ mod integration_tests {
 
         let tokens = tokenize(input);
         let mut parser = Parser::new(tokens);
-        let statements = parser.parse();
-
+        let results = parser.parse();
         let mut env = Environment::new();
+        let (statements, errors) = separate_out_statements_and_parser_errors(results);
         eval_statements(statements.clone(), &mut env);
         assert_eq!(
             env.get_variable("x".into()),
@@ -950,9 +988,9 @@ mod integration_tests {
 
         let tokens = tokenize(input);
         let mut parser = Parser::new(tokens);
-        let statements = parser.parse();
-
+        let results = parser.parse();
         let mut env = Environment::new();
+        let (statements, errors) = separate_out_statements_and_parser_errors(results);
         eval_statements(statements.clone(), &mut env);
         assert_eq!(
             env.get_variable("x".into()),

--- a/src/integration_tests.rs
+++ b/src/integration_tests.rs
@@ -114,6 +114,36 @@ mod integration_tests {
     }
 
     #[test]
+    fn testing_less_than_or_equal_true() {
+        let input = "1 <= 2;";
+        let tokens = tokenize(input);
+        let mut parser = Parser::new(tokens);
+        let statements = parser.parse();
+        let mut env = Environment::new();
+        let expression = match &statements[0] {
+            Statement::ExpressionStatement(expression) => expression,
+            _ => &Expression::NumberLiteral(-255.0),
+        };
+        let result = eval_expression(expression.clone(), &mut env).unwrap();
+        assert_eq!(result, ExpressionResult::Boolean(true));
+    }
+
+    #[test]
+    fn testing_greater_than_or_equal_true() {
+        let input = "2 >= 1;";
+        let tokens = tokenize(input);
+        let mut parser = Parser::new(tokens);
+        let statements = parser.parse();
+        let mut env = Environment::new();
+        let expression = match &statements[0] {
+            Statement::ExpressionStatement(expression) => expression,
+            _ => &Expression::NumberLiteral(-255.0),
+        };
+        let result = eval_expression(expression.clone(), &mut env).unwrap();
+        assert_eq!(result, ExpressionResult::Boolean(true));
+    }
+
+    #[test]
     fn testing_and_true_true() {
         let input = "true && true;";
         let tokens = tokenize(input);

--- a/src/interpreter/errors.rs
+++ b/src/interpreter/errors.rs
@@ -1,5 +1,7 @@
 use std::fmt::Display;
 
+use crate::lexer::Token;
+
 pub enum InterpreterErrorKind {
     ReferenceError(String),
     SyntaxError(Option<SyntaxErrorKind>),
@@ -9,6 +11,8 @@ pub enum InterpreterErrorKind {
 pub enum SyntaxErrorKind {
     LeftSideAssignmentMustBeIdentifier,
     InvalidLeftSidePrefix,
+    UnexpectedToken(Token),
+    UnexpectedIdentifier(String)
 }
 
 impl SyntaxErrorKind {
@@ -19,6 +23,12 @@ impl SyntaxErrorKind {
             }
             Self::InvalidLeftSidePrefix => {
                 "Invalid left-hand side expression in prefix operation".to_string()
+            }
+            Self::UnexpectedToken(token) => {
+                format!("Unexpected token '{:#?}'", token)
+            }
+            Self::UnexpectedIdentifier(identifier) => {
+                format!("Unexpected identifier '{}'", identifier)
             }
         }
     }

--- a/src/interpreter/errors.rs
+++ b/src/interpreter/errors.rs
@@ -1,4 +1,4 @@
-use std::fmt::Display;
+use std::fmt::{Debug, Display};
 
 use crate::lexer::Token;
 
@@ -8,6 +8,12 @@ pub enum InterpreterErrorKind {
     NaN
 }
 
+#[derive(PartialEq)]
+pub enum ParserErrorKind {
+    SyntaxError(Option<SyntaxErrorKind>)
+}
+
+#[derive(PartialEq)]
 pub enum SyntaxErrorKind {
     LeftSideAssignmentMustBeIdentifier,
     InvalidLeftSidePrefix,
@@ -64,6 +70,36 @@ impl InterpreterError {
 }
 
 impl Display for InterpreterError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.to_string())
+    }
+}
+
+#[derive(PartialEq)]
+pub struct ParserError {
+    pub kind: ParserErrorKind
+}
+
+impl ParserError {
+    pub fn to_string(&self) -> String {
+        match &self.kind {
+            ParserErrorKind::SyntaxError(message) => {
+                match message {
+                    Some(error_text) => format!("Uncaught SyntaxError: {}", error_text),
+                    None => "Uncaught SyntaxError".to_string(),
+                }
+            },
+        }
+    }
+}
+
+impl Display for ParserError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.to_string())
+    }
+}
+
+impl Debug for ParserError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.to_string())
     }

--- a/src/interpreter/interpreter.rs
+++ b/src/interpreter/interpreter.rs
@@ -49,8 +49,6 @@ pub fn eval_statement(statement: Statement, env: &mut Environment) -> Option<Exp
                     return Some(value);
                 }
             }
-            // TODO: should be bubbling the error up or something, instead of returning none
-            // so adjust eval_statement to return Result<Option<ExpressionResult>>?
             Some(ExpressionResult::Undefined)
         }
         Statement::ConditionalStatement(condition, block, next_conditional) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use environment::Environment;
 use lexer::tokenize;
 use parser::Parser;
-use crate::interpreter::interpreter::{eval_statements};
+use crate::{interpreter::interpreter::eval_statements, parser::separate_out_statements_and_parser_errors};
 
 mod lexer;
 mod ast;
@@ -24,7 +24,17 @@ fn main() {
 
         let tokens = tokenize(&input);
         let mut parser = Parser::new(tokens);
-        let statements = parser.parse();
-        eval_statements(statements, &mut env);
+        let statement_results = parser.parse();
+
+        let (statements, parser_errors) = separate_out_statements_and_parser_errors(statement_results);
+
+        if parser_errors.len() > 0 {
+            for error in parser_errors {
+                println!("{}", error)
+            }
+        } else {
+            eval_statements(statements, &mut env);
+        }
     }
 }
+

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -217,9 +217,9 @@ impl Parser {
 
     fn parse_paren_wrapped_expression(&mut self) -> Result<Expression, ParserError> {
         if self.expect(&Token::LeftParen) {
-            let mut conditional_expression = self.parse_expression();
+            let conditional_expression = self.parse_expression();
             if !self.expect(&Token::RightParen) {
-                // this is an error
+                return Err(self.unexpected_token());
             }
             return Ok(conditional_expression);
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -183,7 +183,6 @@ impl Parser {
         while self.peek() == &Token::NewLine {
             self.advance();
         }
-        println!("{:#?}", self.peek());
 
         if self.expect(&Token::Else) {
             else_conditional = self.parse_conditional();
@@ -353,9 +352,10 @@ impl Parser {
                 _ => unreachable!(),
             };
             let left = expr.clone();
+            let include_equality = self.expect(&Token::Equals);
             let right = self.parse_term();
             expr = Expression::Operation(Box::new(expr), operator, Box::new(right.clone()));
-            if self.expect(&Token::Equals) {
+            if include_equality {
                 let equal_expression =
                     Expression::Operation(Box::new(left), Operator::Equal, Box::new(right));
                 expr =


### PR DESCRIPTION
Modified the parser to be able to throw syntax errors, and changed all of the statement level parsing to throw syntax errors (previous behavior was to return None or simply have a comment in the code that said that reaching a particular branch meant there was a problem, but silently fail).

As part of this also had to rework some of the function parsing, fixing some new line issues.

Also fixed the <= and >= comparators while digging through the parser.