### PR TITLE
Implement strategy pattern for operators in interpreter

### DIFF
--- a/src/interpreter/errors.rs
+++ b/src/interpreter/errors.rs
@@ -5,7 +5,8 @@ use crate::lexer::Token;
 pub enum InterpreterErrorKind {
     ReferenceError(String),
     SyntaxError(Option<SyntaxErrorKind>),
-    NaN
+    NaN,
+    DivisionByZero
 }
 
 #[derive(PartialEq)]
@@ -65,6 +66,9 @@ impl InterpreterError {
             InterpreterErrorKind::NaN => {
                 "NaN".to_string()
             },
+            InterpreterErrorKind::DivisionByZero => {
+                "Infinity".to_string()
+            }
         }
     }
 }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1,5 +1,6 @@
-pub mod interpreter;
 pub mod errors;
+pub mod interpreter;
+pub mod operators;
 pub mod visitor;
 
 pub use interpreter::*;

--- a/src/interpreter/operators.rs
+++ b/src/interpreter/operators.rs
@@ -89,7 +89,7 @@ impl BinaryOperator for DivideOperator {
         _env: &mut Environment,
     ) -> Result<ExpressionResult, String> {
         if let (Ok(l), Ok(r)) = (left.coerce_to_number(), right.coerce_to_number()) {
-            if r == 0.0 {
+            if r.abs() < f64::EPSILON {
                 Err(InterpreterError {
                     kind: InterpreterErrorKind::DivisionByZero
                 }

--- a/src/interpreter/operators.rs
+++ b/src/interpreter/operators.rs
@@ -1,0 +1,306 @@
+use crate::ast::{ExpressionResult, Operator};
+use crate::environment::Environment;
+use crate::interpreter::errors::{InterpreterError, InterpreterErrorKind};
+
+pub trait BinaryOperator {
+    fn apply(
+        &self,
+        left: ExpressionResult,
+        right: ExpressionResult,
+        env: &mut Environment
+    ) -> Result<ExpressionResult, String>;
+}
+
+/// AddOperator is the more complicated than the other arithmetic operators
+/// because it also handles string concatenation on top of numeric addition.
+pub struct AddOperator;
+impl BinaryOperator for AddOperator {
+    fn apply(
+        &self,
+        left: ExpressionResult,
+        right: ExpressionResult,
+        _env: &mut Environment
+    ) -> Result<ExpressionResult, String> {
+        if matches!(left, ExpressionResult::String(_))
+            || matches!(right, ExpressionResult::String(_))
+        {
+            let new_string = left.coerce_to_string() + &right.coerce_to_string();
+            Ok(ExpressionResult::String(new_string))
+        } else {
+            let left_num = left.coerce_to_number();
+            let right_num = right.coerce_to_number();
+            if let (Ok(l), Ok(r)) = (left_num, right_num) {
+                Ok(ExpressionResult::Number(l + r))
+            } else {
+                Err(InterpreterError {
+                    kind: InterpreterErrorKind::NaN,
+                }
+                .to_string())
+            }
+        }
+    }
+}
+
+pub struct SubtractOperator;
+impl BinaryOperator for SubtractOperator {
+    fn apply(
+        &self,
+        left: ExpressionResult,
+        right: ExpressionResult,
+        _env: &mut Environment,
+    ) -> Result<ExpressionResult, String> {
+        if let (Ok(l), Ok(r)) = (left.coerce_to_number(), right.coerce_to_number()) {
+            Ok(ExpressionResult::Number(l - r))
+        } else {
+            Err(InterpreterError {
+                kind: InterpreterErrorKind::NaN,
+            }
+            .to_string())
+        }
+    }
+}
+
+pub struct MultiplyOperator;
+impl BinaryOperator for MultiplyOperator {
+    fn apply(
+        &self,
+        left: ExpressionResult,
+        right: ExpressionResult,
+        _env: &mut Environment,
+    ) -> Result<ExpressionResult, String> {
+        if let (Ok(l), Ok(r)) = (left.coerce_to_number(), right.coerce_to_number()) {
+            Ok(ExpressionResult::Number(l * r))
+        } else {
+            Err(InterpreterError {
+                kind: InterpreterErrorKind::NaN,
+            }
+            .to_string())
+        }
+    }
+}
+
+/// Division needs special handling for division by zero
+pub struct DivideOperator;
+impl BinaryOperator for DivideOperator {
+    fn apply(
+        &self,
+        left: ExpressionResult,
+        right: ExpressionResult,
+        _env: &mut Environment,
+    ) -> Result<ExpressionResult, String> {
+        if let (Ok(l), Ok(r)) = (left.coerce_to_number(), right.coerce_to_number()) {
+            if r == 0.0 {
+                Err(InterpreterError {
+                    kind: InterpreterErrorKind::DivisionByZero
+                }
+                .to_string())
+            } else {
+                Ok(ExpressionResult::Number(l / r))
+            }
+        } else {
+            Err(InterpreterError {
+                kind: InterpreterErrorKind::NaN,
+            }
+            .to_string())
+        }
+    }
+}
+
+pub struct ModuloOperator;
+impl BinaryOperator for ModuloOperator {
+    fn apply(
+        &self,
+        left: ExpressionResult,
+        right: ExpressionResult,
+        _env: &mut Environment,
+    ) -> Result<ExpressionResult, String> {
+        if let (Ok(l), Ok(r)) = (left.coerce_to_number(), right.coerce_to_number()) {
+            Ok(ExpressionResult::Number(l % r))
+        } else {
+            Err(InterpreterError {
+                kind: InterpreterErrorKind::NaN,
+            }
+            .to_string())
+        }
+    }
+}
+
+pub struct ExponentiationOperator;
+impl BinaryOperator for ExponentiationOperator {
+    fn apply(
+        &self,
+        left: ExpressionResult,
+        right: ExpressionResult,
+        _env: &mut Environment,
+    ) -> Result<ExpressionResult, String> {
+        if let (Ok(l), Ok(r)) = (left.coerce_to_number(), right.coerce_to_number()) {
+            Ok(ExpressionResult::Number(l.powf(r)))
+        } else {
+            Err(InterpreterError {
+                kind: InterpreterErrorKind::NaN,
+            }
+            .to_string())
+        }
+    }
+}
+
+pub struct EqualOperator;
+impl BinaryOperator for EqualOperator {
+    fn apply(
+        &self,
+        left: ExpressionResult,
+        right: ExpressionResult,
+        _env: &mut Environment,
+    ) -> Result<ExpressionResult, String> {
+        if matches!(left, ExpressionResult::Boolean(_))
+            || matches!(right, ExpressionResult::Boolean(_))
+        {
+            return Ok(ExpressionResult::Boolean(
+                left.coerce_to_bool() == right.coerce_to_bool(),
+            ));
+        }
+
+        if matches!(left, ExpressionResult::Number(_))
+            || matches!(right, ExpressionResult::Number(_))
+        {
+            let left_num = left.coerce_to_number();
+            let right_num = right.coerce_to_number();
+            if let (Ok(l), Ok(r)) = (left_num, right_num) {
+                return Ok(ExpressionResult::Boolean(l == r));
+            } else {
+                return Err(InterpreterError {
+                    kind: InterpreterErrorKind::NaN,
+                }
+                .to_string());
+            }
+        }
+
+        Ok(ExpressionResult::Boolean(
+            left.coerce_to_string() == right.coerce_to_string(),
+        ))
+    }
+}
+
+pub struct LessThanOperator;
+impl BinaryOperator for LessThanOperator {
+    fn apply(
+        &self,
+        left: ExpressionResult,
+        right: ExpressionResult,
+        _env: &mut Environment,
+    ) -> Result<ExpressionResult, String> {
+        if let (Ok(l), Ok(r)) = (left.coerce_to_number(), right.coerce_to_number()) {
+            Ok(ExpressionResult::Boolean(l < r))
+        } else {
+            Ok(ExpressionResult::Boolean(false))
+        }
+    }
+}
+
+pub struct GreaterThanOperator;
+impl BinaryOperator for GreaterThanOperator {
+    fn apply(
+        &self,
+        left: ExpressionResult,
+        right: ExpressionResult,
+        _env: &mut Environment,
+    ) -> Result<ExpressionResult, String> {
+        if let (Ok(l), Ok(r)) = (left.coerce_to_number(), right.coerce_to_number()) {
+            Ok(ExpressionResult::Boolean(l > r))
+        } else {
+            Ok(ExpressionResult::Boolean(false))
+        }
+    }
+}
+
+pub struct AndOperator;
+impl BinaryOperator for AndOperator {
+    fn apply(
+        &self,
+        left: ExpressionResult,
+        right: ExpressionResult,
+        _env: &mut Environment,
+    ) -> Result<ExpressionResult, String> {
+        Ok(ExpressionResult::Boolean(
+            left.coerce_to_bool() && right.coerce_to_bool(),
+        ))
+    }
+}
+
+pub struct OrOperator;
+impl BinaryOperator for OrOperator {
+    fn apply(
+        &self,
+        left: ExpressionResult,
+        right: ExpressionResult,
+        _env: &mut Environment,
+    ) -> Result<ExpressionResult, String> {
+        Ok(ExpressionResult::Boolean(
+            left.coerce_to_bool() || right.coerce_to_bool(),
+        ))
+    }
+}
+
+pub fn get_operator_strategy(operator: Operator) -> Box<dyn BinaryOperator> {
+    match operator {
+        Operator::Add => Box::new(AddOperator),
+        Operator::Subtract => Box::new(SubtractOperator),
+        Operator::Multiply => Box::new(MultiplyOperator),
+        Operator::Divide => Box::new(DivideOperator),
+        Operator::Modulo => Box::new(ModuloOperator),
+        Operator::Equal => Box::new(EqualOperator),
+        Operator::LessThan => Box::new(LessThanOperator),
+        Operator::GreaterThan => Box::new(GreaterThanOperator),
+        Operator::And => Box::new(AndOperator),
+        Operator::Or => Box::new(OrOperator),
+        Operator::Exponentiation => Box::new(ExponentiationOperator),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_operator_should_concatenate_strings() {
+        let left = ExpressionResult::String("Hello, ".into());
+        let right = ExpressionResult::String("world!".into());
+        let operator = AddOperator;
+        let result = operator.apply(left, right, &mut Environment::new()).unwrap();
+        assert_eq!(result, ExpressionResult::String("Hello, world!".into()));
+    }
+
+    #[test]
+    fn add_operator_should_add_numbers() {
+        let left = ExpressionResult::Number(5.0);
+        let right = ExpressionResult::Number(3.0);
+        let operator = AddOperator;
+        let result = operator.apply(left, right, &mut Environment::new()).unwrap();
+        assert_eq!(result, ExpressionResult::Number(8.0));
+    }
+
+    #[test]
+    fn add_operator_should_handle_string_and_number() {
+        let left = ExpressionResult::String("The answer is ".into());
+        let right = ExpressionResult::Number(42.0);
+        let operator = AddOperator;
+        let result = operator.apply(left, right, &mut Environment::new()).unwrap();
+        assert_eq!(result, ExpressionResult::String("The answer is 42".into()));
+    }
+
+    #[test]
+    fn divide_operator_should_handle_division_by_zero() {     
+        let left = ExpressionResult::Number(10.0);
+        let right = ExpressionResult::Number(0.0);
+        let operator = DivideOperator;
+        let result = operator.apply(left, right, &mut Environment::new());
+        assert!(result.is_err());
+        assert_eq!(
+            result.err().unwrap(),
+            InterpreterError {
+                kind: InterpreterErrorKind::DivisionByZero
+            }
+            .to_string()
+        );
+    }
+}

--- a/src/interpreter/visitor.rs
+++ b/src/interpreter/visitor.rs
@@ -63,8 +63,8 @@ impl<'a> Evaluator<'a> {
                     } else {
                         1.0
                     };
-                    let coersion = value.coerce_to_number();
-                    if let Ok(number) = coersion {
+                    let coercion = value.coerce_to_number();
+                    if let Ok(number) = coercion {
                         return Ok(ExpressionResult::Number(sign * number));
                     } else {
                         return Err(InterpreterError {

--- a/src/interpreter/visitor.rs
+++ b/src/interpreter/visitor.rs
@@ -1,9 +1,12 @@
 use crate::ast::{Expression, ExpressionResult, Operator, PrefixOperator, Statement, Node};
 use crate::environment::Environment;
-use crate::interpreter::errors::{InterpreterError, InterpreterErrorKind, SyntaxErrorKind};
+use crate::interpreter::{
+    errors::{InterpreterError, InterpreterErrorKind, SyntaxErrorKind},
+    operators::get_operator_strategy,
+};
 
 /// Trait for visiting AST nodes.
-/// 
+///
 /// Statements return `Option<ExpressionResult>` to allow early returns,
 /// while expressions return a `Result<ExpressionResult, String>` to surface runtime errors.
 pub trait NodeVisitor {
@@ -20,185 +23,33 @@ impl<'a> Evaluator<'a> {
         Self { env }
     }
 
-    fn handle_operation_expression(
-        &mut self,
-        left_hand: &Expression,
-        operator: &Operator,
-        right_hand: &Expression
-    ) -> Result<ExpressionResult, String> {
-        match operator {
-            // currently these operators always treat both sides as boolean
-            Operator::And | Operator::Or => {
-                return self.handle_and_or_with_short_circuiting(left_hand, operator, right_hand);
-            }
-            // currently these operators treat both sides as numbers, and if either side is not a number, return false
-            Operator::LessThan | Operator::GreaterThan => {
-                return self.handle_comparators(left_hand, operator, right_hand);
-            }
-            // this really only makes sense for values that can be coerced to numbers, and will either return a number or NaN
-            Operator::Multiply | Operator::Divide | Operator::Subtract | Operator::Modulo => {
-                if let Ok(left_result) = left_hand.accept(self) {
-                    if let Ok(right_result) = right_hand.accept(self)  {
-                        if let Ok(left_as_num) = left_result.coerce_to_number() {
-                            if let Ok(right_as_num) = right_result.coerce_to_number() {
-                                if *operator == Operator::Multiply {
-                                    return Ok(ExpressionResult::Number(left_as_num * right_as_num));
-                                } else if *operator == Operator::Divide {
-                                    return Ok(ExpressionResult::Number(left_as_num / right_as_num));
-                                } else if *operator == Operator::Subtract {
-                                    return Ok(ExpressionResult::Number(left_as_num - right_as_num));
-                                } else if *operator == Operator::Modulo {
-                                    return Ok(ExpressionResult::Number(left_as_num % right_as_num));
-                                }
-                            }
-                        }
-                    }
-                }
-                return Err(InterpreterError {
-                    kind: InterpreterErrorKind::NaN,
-                }
-                .to_string());
-            }
-            Operator::Add => {
-                if let Ok(left_result) = left_hand.accept(self) {
-                    if let Ok(right_result) = right_hand.accept(self)  {
-                        // if either side is a string, convert both sides to string and concatenate
-                        if matches!(left_result, ExpressionResult::String(_))
-                            || matches!(right_result, ExpressionResult::String(_))
-                        {
-                            let new_string =
-                                left_result.coerce_to_string() + &right_result.coerce_to_string();
-                            return Ok(ExpressionResult::String(new_string));
-                        } else {
-                            // otherwise convert to number and add
-                            // If either side can't convert, return NaN
-                            let left_num_res = left_result.coerce_to_number();
-                            let right_num_res = right_result.coerce_to_number();
-                            if let Ok(left_num) = left_num_res {
-                                if let Ok(right_num) = right_num_res {
-                                    return Ok(ExpressionResult::Number(left_num + right_num));
-                                }
-                            }
-                            return Err(InterpreterError {
-                                kind: InterpreterErrorKind::NaN,
-                            }
-                            .to_string());
-                        }
-                    }
-                }
-                return Err("Could not complete request".to_string());
-            }
-            Operator::Equal => {
-                if let Ok(left_result) = left_hand.accept(self) {
-                    if let Ok(right_result) = right_hand.accept(self)  {
-                        // if either side is a boolean, then check other side for truthiness
-                        if matches!(left_result, ExpressionResult::Boolean(_))
-                            || matches!(right_result, ExpressionResult::Boolean(_))
-                        {
-                            return Ok(ExpressionResult::Boolean(
-                                left_result.coerce_to_bool() == right_result.coerce_to_bool(),
-                            ));
-                        }
-                        // if either side is a number, then try coercion to number
-                        if matches!(left_result, ExpressionResult::Number(_))
-                            || matches!(right_result, ExpressionResult::Number(_))
-                        {
-                            let left_num_res = left_result.coerce_to_number();
-                            let right_num_res = right_result.coerce_to_number();
-                            if let Ok(left_num) = left_num_res {
-                                if let Ok(right_num) = right_num_res {
-                                    return Ok(ExpressionResult::Boolean(left_num == right_num));
-                                }
-                            }
-                            return Err(InterpreterError {
-                                kind: InterpreterErrorKind::NaN,
-                            }
-                            .to_string());
-                        }
-                        // at this point both sides must be strings, check if the strings are the same
-                        return Ok(ExpressionResult::Boolean(
-                            left_result.coerce_to_string() == right_result.coerce_to_string(),
-                        ));
-                    }
-                }
-                return Err("Could not complete request".to_string());
-            }
-            Operator::Exponentiation => {
-                if let Ok(right_result) = right_hand.accept(self)  {
-                    if let Ok(right_value) = right_result.coerce_to_number() {
-                        if let Ok(left_result) = left_hand.accept(self) {
-                            if let Ok(left_value) = left_result.coerce_to_number() {
-                                let value = left_value.powf(right_value);
-                                return Ok(ExpressionResult::Number(value));
-                            }
-                        }
-                    }
-                }
-                return Err(InterpreterError {
-                    kind: InterpreterErrorKind::NaN,
-                }
-                .to_string());
-            }
-        }
-    }
-
-    fn handle_comparators(
+    fn evaluate_operation_expression(
         &mut self,
         left_hand: &Expression,
         operator: &Operator,
         right_hand: &Expression,
     ) -> Result<ExpressionResult, String> {
         let left_result = left_hand.accept(self);
-        let right_result = right_hand.accept(self);
-        if let Ok(left_expression_result) = left_result {
-            if let Ok(right_expression_result) = right_result {
-                if let Ok(left_num) = left_expression_result.coerce_to_number() {
-                    if let Ok(right_num) = right_expression_result.coerce_to_number() {
-                        if *operator == Operator::LessThan {
-                            return Ok(ExpressionResult::Boolean(left_num < right_num));
-                        } else {
-                            return Ok(ExpressionResult::Boolean(left_num > right_num));
-                        }
-                    }
-                }
-            }
-        }
-        return Ok(ExpressionResult::Boolean(false));
-    }
-
-    fn handle_and_or_with_short_circuiting(
-        &mut self,
-        left_hand: &Expression,
-        operator: &Operator,
-        right_hand: &Expression,
-    ) -> Result<ExpressionResult, String> {
-        if let Ok(left_result) = left_hand.accept(self) {
-            let left_bool = left_result.coerce_to_bool();
-            if *operator == Operator::And && left_bool == false {
-                // short circuit, don't eval right hand side, just return false
+        if let Ok(left_value) = left_result {
+            // short circuit behavior for logical operators
+            if *operator == Operator::And && !left_value.coerce_to_bool() {
                 return Ok(ExpressionResult::Boolean(false));
             }
-            if *operator == Operator::Or && left_bool == true {
-                // short circuit, don't eval right hand side, just return true
+            if *operator == Operator::Or && left_value.coerce_to_bool() {
                 return Ok(ExpressionResult::Boolean(true));
-            } else {
-                if let Ok(right_result) = right_hand.accept(self) {
-                    let right_bool = right_result.coerce_to_bool();
-                    if *operator == Operator::And {
-                        return Ok(ExpressionResult::Boolean(left_bool && right_bool));
-                    } else {
-                        return Ok(ExpressionResult::Boolean(left_bool || right_bool));
-                    }
-                }
             }
+            let right_value = right_hand.accept(self)?;
+            let strategy = get_operator_strategy(operator.clone());
+            strategy.apply(left_value, right_value, self.env)
+        } else {
+            Err(InterpreterError {
+                kind: InterpreterErrorKind::SyntaxError(None),
+            }
+            .to_string())
         }
-        Err(InterpreterError {
-            kind: InterpreterErrorKind::SyntaxError(None),
-        }
-        .to_string())
     }
 
-    fn handle_prefix_expression(
+    fn evaluate_prefix_expression(
         &mut self,
         operator: &PrefixOperator,
         expression: &Expression,
@@ -369,10 +220,10 @@ impl<'a> NodeVisitor for Evaluator<'a> {
             }
             Expression::String(string) => Ok(ExpressionResult::String(string.clone())),
             Expression::Prefix(operator, expression) => {
-                self.handle_prefix_expression(operator, expression)
+                self.evaluate_prefix_expression(operator, expression)
             }
             Expression::Operation(left_hand, operator, right_hand) => {
-                self.handle_operation_expression(left_hand, operator, right_hand)
+                self.evaluate_operation_expression(left_hand, operator, right_hand)
             }
             Expression::Assignment(left_hand, right_hand) => match &**left_hand {
                 Expression::Identifier(identifier) => {


### PR DESCRIPTION
Refactor the operator handling by implementing a strategy pattern, moving logic out of the evaluate operation function. This change enhances code organization and maintainability. Additionally, introduce error handling for division by zero.